### PR TITLE
Set invalid values for inputs, great for username/email already taken

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -21,10 +21,8 @@ Event.ready( function(){
 
     Event.bubbleFormEvents()
 
-    Event.on( document.body, {
-      invalid: function( event ) { event.preventDefault() },  // Suppress default message bubbles
-      submit: submit
-    })
+    document.addEventListener( 'invalid', function( event ) { event.preventDefault(); }, true )
+    Event.on( document.body, 'submit', submit )
 
     // Watch input events
     Event.on( document, 'blur', '[required]', checkValidation )
@@ -99,28 +97,41 @@ function isValid ( input ) {
     input.value = ''
 
   // Set a custom validation message for word count
-  if ( input.dataset.minWords ) checkCount( input, 'min' )
-  if ( input.dataset.maxWords ) checkCount( input, 'max' )
+  var message = checkCount( input, 'min' )
+             || checkCount( input, 'max' )
+             || checkValue( input ) 
+             || ''
+
+  input.setCustomValidity( message )
 
   return input.checkValidity()
 
 }
 
+function checkValue( input ) {
+  var invalid = input.dataset.invalidValue
+
+  if ( invalid && input.value.match( new RegExp('^'+invalid+'$', 'i') ) ) {
+    return input.dataset.invalidValueMessage || "Cannot equal '"+invalid+"'"
+  }
+}
+
 // Test custom validation for maximum or minimum words present
 function checkCount ( input, limit ) {
 
-  var goal         = input.dataset[ limit + 'Words' ],
-      lessThanGoal = wordCount( input.value ) < goal
+  var goal = input.dataset[ limit + 'Words' ]
 
-  var phrasing     = ( limit == 'min' ) ? 'at least ' : 'no more than ',
-      valid        = ( limit == 'min' ) ? !lessThanGoal : lessThanGoal,
-      message      = '';
+  if ( goal ) {
 
-  // Set a custom error message
-  if ( input.value && !valid )
-    message = 'Please write ' + phrasing + goal + ' words.'
+    var lessThanGoal = wordCount( input.value ) < goal
+        phrasing     = ( limit == 'min' ) ? 'at least ' : 'no more than ',
+        valid        = ( limit == 'min' ) ? !lessThanGoal : lessThanGoal
 
-  input.setCustomValidity( message )
+    // Return a custom error message
+    if ( input.value && !valid )
+      return 'Please write ' + phrasing + goal + ' words.'
+  }
+
 
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,26 @@ describe( 'formup', function() {
       fieldsetOne.removeChild( fieldsetOne.lastChild )
     })
 
+    it( 'tests invalid values', function() {
+
+      var input = utils.addInput( fieldsetOne, { 'data-invalid-value': 'nope@nope.com' })
+
+      setValue( input, 'nope@nope.com' )
+      isInvalid( input )
+      formUp.validate( form )
+      assert.equal( input.parentNode.textContent, "Cannot equal 'nope@nope.com'" )
+
+      input.dataset.invalidValueMessage = 'Email address already registered'
+      formUp.validate( form )
+      assert.equal( input.parentNode.textContent, "Email address already registered" )
+
+      setValue( input, 'foo@bar.com' )
+      isValid( input )
+
+      fieldsetOne.removeChild( fieldsetOne.lastChild )
+
+    })
+
     it( 'tests maximum words', function() {
 
       var input = utils.addInput( fieldsetOne, { 'data-max-words': '3' })


### PR DESCRIPTION
This allows inputs to exclude values from `data-invalid-value='whatever'` and sets messages to "Cannot equal "whatever" or `data-invalid-value-message='Username "whatever" is already taken.'`