### PR TITLE
Browser support

### DIFF
--- a/lib/progressive.js
+++ b/lib/progressive.js
@@ -54,6 +54,9 @@ function newForm( form ) {
 
     if ( timer ) { Event.delay( show, timer ) }
     else { show() }
+    Event.afterAnimation( currentStep(), function() {
+      Event.fire( toolbox.getClosest(currentStep(), 'form'), 'validate' )
+    })
 
   }
 
@@ -97,7 +100,7 @@ function newForm( form ) {
 
     // Continue if submit was triggered on this form
     // and no invalid fields are found
-    if ( form == event.target && !currentStep().querySelector( ':invalid' ) ) {
+    if ( form == toolbox.getClosest( event.target, 'form' ) && !currentStep().querySelector( ':invalid' ) ) {
 
       // If a step remains, stop the form submission
       if ( nextStep() ) { event.preventDefault() }
@@ -188,7 +191,7 @@ Event.ready( function(){
   // Add bubbling so we can listen for submission
   Event.bubbleFormEvents()
 
-  Event.on( document, 'submit', formSelector, fire )
+  Event.on( document, 'click', formSelector + ' [type=submit]', fire )
 
   Event.change( function() {
     reset()

--- a/lib/progressive.js
+++ b/lib/progressive.js
@@ -100,7 +100,10 @@ function newForm( form ) {
 
     // Continue if submit was triggered on this form
     // and no invalid fields are found
-    if ( form == toolbox.getClosest( event.target, 'form' ) && !currentStep().querySelector( ':invalid' ) ) {
+
+    var formEl = ( event.target.tagName == "FORM" ) ? event.target : toolbox.getClosest( event.target, 'form')
+
+    if ( form == formEl && !currentStep().querySelector( ':invalid' ) ) {
 
       // If a step remains, stop the form submission
       if ( nextStep() ) { event.preventDefault() }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -28,7 +28,6 @@ Event.ready( function(){
     document.addEventListener( 'invalid', invalidHandler, true )
 
     Event.on( document.body, 'click', '[type=submit]', submit )
-    Event.on( document, 'submit', submit )
 
     Event.on( document, 'validate', 'form', function( event ) { 
       validateForm( event.target )
@@ -67,7 +66,9 @@ function validateForm ( form ) {
   }
 
   // The form is valid, skip it
-  else { return true }
+  else { 
+    return true 
+  }
 
 }
 
@@ -192,6 +193,7 @@ function focus ( el ) {
 function submit ( event ) {
 
   var form = ( event.target.tagName == "FORM" ) ? event.target : getClosest( event.target, 'form')
+
   // Skip validation if no invalid inputs found
   if ( !validateForm( form ) ) {
 
@@ -201,7 +203,7 @@ function submit ( event ) {
 
     // Stop the submission event
     event.preventDefault()
-    event.stopPropagation()
+    event.stopImmediatePropagation()
 
   }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -136,7 +136,7 @@ function checkValue( input ) {
       input.dataset.cachedMessage = input.dataset.message
       input.dataset.message = ''
 
-      return input.dataset.invalidValueMessage || "Cannot equal '"+input.value+"'"
+      return input.dataset.invalidValueMessage || "Value '"+input.value+"' is not permitted"
 
     // If not invalid value reset standard validation message
     } else if ( input.dataset.cachedMessage ) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -13,6 +13,10 @@ function supported () {
 
 }
 
+var invalidHandler = Event.callback.new( function( event ) { 
+  event.preventDefault() 
+  event.stopPropagation() 
+})
 
 // Watch for events ( if validation is suported )
 Event.ready( function(){
@@ -21,12 +25,19 @@ Event.ready( function(){
 
     Event.bubbleFormEvents()
 
-    document.addEventListener( 'invalid', function( event ) { event.preventDefault(); }, true )
-    Event.on( document.body, 'submit', submit )
+    document.addEventListener( 'invalid', invalidHandler, true )
+
+    Event.on( document.body, 'click', '[type=submit]', submit )
+    Event.on( document, 'submit', submit )
+
+    Event.on( document, 'validate', 'form', function( event ) { 
+      validateForm( event.target )
+    })
 
     // Watch input events
     Event.on( document, 'blur', '[required]', checkValidation )
-    Event.on( document, 'input', '[required]', Event.debounce( checkValidation, 200 ) )
+    Event.on( document, 'keydown', '[required]', Event.debounce( checkValidation, 200 ) )
+    Event.on( document, 'input', 'select[required]', Event.debounce( checkValidation, 200 ) )
 
   }
 })
@@ -34,37 +45,40 @@ Event.ready( function(){
 function validateForm ( form ) {
 
   // Scoped variables
-  var invalidInput = form.querySelector( 'input:invalid, textarea:invalid, select:invalid' )
+  var inputs = form.querySelectorAll( '[required]' ),
+      invalidInput;
 
-  // The form is valid, skip it
-  if ( !invalidInput ) { 
+  toolbox.slice( inputs ).some( function( input ) {
 
-    return true
+    // if visible and invalid
+    if ( !checkInput( input ) ) {
+      invalidInput = input
+      return true
+    }
+  })
 
-  }
-
-  else {
-
-    // Set validity state on element
-    checkInput( invalidInput )
+  if ( invalidInput ) { 
 
     // Show validation message
-    showMessage( invalidInput )
     focus( invalidInput )
+    showMessage( invalidInput )
 
     return false
-
   }
+
+  // The form is valid, skip it
+  else { return true }
 
 }
 
 // Handler for validation events
 var checkValidation = Event.callback.new( function( event ) {
 
-  // Remove any pre-existing validation message
-  hideMessage( event.target )
+  if ( checkInput( event.target, event.type ) ) {
 
-  checkInput( event.target, event.type )
+    // Remove any pre-existing validation message
+    hideMessage( event.target )
+  }
 
 })
 
@@ -73,7 +87,7 @@ function checkInput ( input, event ) {
 
   var el       = statusEl( input ),
       valid    = isValid( input ),
-      neutral  = !valid && event == 'input';
+      neutral  = event == 'keydown' && !valid;
 
   // Don't trigger invalid style while typing
   if ( neutral && input == document.activeElement ) {
@@ -87,6 +101,8 @@ function checkInput ( input, event ) {
 
   }
 
+  return valid
+
 }
 
 // Is an input valid?
@@ -97,23 +113,43 @@ function isValid ( input ) {
     input.value = ''
 
   // Set a custom validation message for word count
-  var message = checkCount( input, 'min' )
-             || checkCount( input, 'max' )
-             || checkValue( input ) 
-             || ''
-
+  var message = checkValue( input ) || checkLength( input ) || ''
   input.setCustomValidity( message )
 
-  return input.checkValidity()
+  var valid = input.checkValidity()
+
+  return valid
 
 }
 
-function checkValue( input ) {
-  var invalid = input.dataset.invalidValue
 
-  if ( invalid && input.value.match( new RegExp('^'+invalid+'$', 'i') ) ) {
-    return input.dataset.invalidValueMessage || "Cannot equal '"+invalid+"'"
+function checkValue( input ) {
+  if ( input.dataset.invalidValue ) {
+
+    // Does input value == invalid value? (case insensitive)
+    var regexp = new RegExp('^'+input.dataset.invalidValue+'$', 'i')
+
+    if ( input.value.match( regexp ) ) {
+
+      // Remove any standard custom message
+      input.dataset.cachedMessage = input.dataset.message
+      input.dataset.message = ''
+
+      return input.dataset.invalidValueMessage || "Cannot equal '"+input.value+"'"
+
+    // If not invalid value reset standard validation message
+    } else if ( input.dataset.cachedMessage ) {
+
+      input.dataset.message = input.dataset.cachedMessage
+      input.dataset.cachedMessage = ''
+
+    }
   }
+}
+
+function checkLength ( input ) {
+  return checkCount( input, 'min' )
+      || checkCount( input, 'max' )
 }
 
 // Test custom validation for maximum or minimum words present
@@ -155,8 +191,9 @@ function focus ( el ) {
 // Submission validation handler function
 function submit ( event ) {
 
+  var form = ( event.target.tagName == "FORM" ) ? event.target : getClosest( event.target, 'form')
   // Skip validation if no invalid inputs found
-  if ( !validateForm( event.target ) ) {
+  if ( !validateForm( form ) ) {
 
     // Pause keydown/blur triggers for the next second to avoid neutral empty style
     checkValidation.stop()
@@ -164,6 +201,7 @@ function submit ( event ) {
 
     // Stop the submission event
     event.preventDefault()
+    event.stopPropagation()
 
   }
 

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -42,7 +42,7 @@ var Utils = {
   },
 
   submit: function( form ) {
-    Event.fire( form, 'submit' )
+    Event.fire( form.querySelector('[type=submit]'), 'click' )
   },
 
   setValue: function( input, value ) {

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,8 @@ var assert    = require( 'chai' ).assert,
 describe( 'formup', function() {
 
   var form = utils.injectHTML( utils.container(), '<form class="progressive"></form>' )
-  form.innerHTML = '<fieldset id="fieldsetOne" class="form-step"></fieldset>\
+  form.innerHTML = '<button type="submit">Submit</button>\
+    <fieldset id="fieldsetOne" class="form-step"></fieldset>\
     <fieldset id="fieldsetTwo" class="form-step"></fieldset>\
     <fieldset class="form-step"></fieldset>'
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,7 @@ describe( 'formup', function() {
       setValue( input, 'nope@nope.com' )
       isInvalid( input )
       formUp.validate( form )
-      assert.equal( input.parentNode.textContent, "Cannot equal 'nope@nope.com'" )
+      assert.equal( input.parentNode.textContent, "Value 'nope@nope.com' is not permitted" )
 
       input.dataset.invalidValueMessage = 'Email address already registered'
       formUp.validate( form )


### PR DESCRIPTION
- When Chrome finds an error on a form, the submit event is not fired

Listening to `click` on `[type=submit]` (annoyingly enough) seems to
be better than listening to submit events. Why do we have a click
event instead of an "attempt-to-submit" event? I blame onClick
handlers and bad coffee.

- New validation test: Invalid Value.

This lets us add additional validation tests to a field where typical validation passes. For
example if you have a username, you may require it to be a certain
length, if that is satisfied, you may also check to see if it is in
use. If a username is in use, you can set `dataset.invalidValue = input.value`
Then set `dataset.invalidValueMessage="This username is already in use"
This will allow current validation to continue to work, while also
notifying the user that this specific value cannot be used.